### PR TITLE
Change the arrow's color with the last exit code

### DIFF
--- a/honukai.zsh-theme
+++ b/honukai.zsh-theme
@@ -38,6 +38,9 @@ ys_hg_prompt_info() {
 	fi
 }
 
+# Command exit code
+local exit_code='%(?.%{$terminfo[bold]$fg[green]%}.%{$terminfo[bold]$fg[red]%})'
+
 # Prompt format: \n # USER at MACHINE in DIRECTORY on git:BRANCH STATE [TIME] \n $
 PROMPT="
 %{$terminfo[bold]$fg[blue]%}#%{$reset_color%} \
@@ -49,7 +52,7 @@ PROMPT="
 ${hg_info}\
 ${git_info} \
 %{$fg[white]%}[%*]
-%{$terminfo[bold]$fg[red]%}→ %{$reset_color%}"
+${exit_code}→ %{$reset_color%}"
 
 if [[ "$USER" == "root" ]]; then
 PROMPT="
@@ -62,5 +65,5 @@ PROMPT="
 ${hg_info}\
 ${git_info} \
 %{$fg[white]%}[%*]
-%{$terminfo[bold]$fg[red]%}→ %{$reset_color%}"
+${exit_code}→ %{$reset_color%}"
 fi


### PR DESCRIPTION
When the exit code reports an error, color the arrow in red; otherwise, color it in green.
<img width="763" alt="screen shot 2016-09-06 at 9 56 29 pm" src="https://cloud.githubusercontent.com/assets/6233736/18288749/02bc941e-747d-11e6-984e-a794d06cacb7.png">
